### PR TITLE
Rename gem to `heroicons`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Declare your gem's dependencies in heroicon-ruby.gemspec.
+# Declare your gem's dependencies in heroicons.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Heroicon
 
-[![Gem Version](https://badge.fury.io/rb/heroicon-ruby.svg)](https://rubygems.org/gems/heroicon-ruby)
-[![Build Status](https://github.com/jclusso/heroicon-ruby/workflows/CI/badge.svg)](https://github.com/jclusso/heroicon-ruby/actions)
+[![Gem Version](https://badge.fury.io/rb/heroicons.svg)](https://rubygems.org/gems/heroicons)
+[![Build Status](https://github.com/jclusso/heroicons/workflows/CI/badge.svg)](https://github.com/jclusso/heroicons/actions)
 
 Ruby on Rails view helpers for the beautiful hand-crafted SVG icons, Heroicons.
 
 This gem has no official affiliation with Tailwind CSS or the Heroicon team. Check out their sites:
 
-- [Tailwind CSS](https://tailwindcss.com/?utm_source=jclusso_heroicon-ruby_github)
-- [Tailwind UI](https://tailwindui.com/?utm_source=jclusso_heroicon-ruby_github)
-- [Heroicons](https://heroicons.com/?utm_source=jclusso_heroicon-ruby_github)
+- [Tailwind CSS](https://tailwindcss.com/?utm_source=jclusso_heroicons_github)
+- [Tailwind UI](https://tailwindui.com/?utm_source=jclusso_heroicons_github)
+- [Heroicons](https://heroicons.com/?utm_source=jclusso_heroicons_github)
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "heroicon-ruby"
+gem "heroicons"
 ```
 
 And then execute:
@@ -99,15 +99,15 @@ Disabling the default class in the view:
 
 Anyone is encouraged to help improve this project. Here are a few ways you can help:
 
-- [Report bugs](https://github.com/jclusso/heroicon-ruby/issues)
-- Fix bugs and [submit pull requests](https://github.com/jclusso/heroicon-ruby/pulls)
+- [Report bugs](https://github.com/jclusso/heroicons/issues)
+- Fix bugs and [submit pull requests](https://github.com/jclusso/heroicons/pulls)
 - Write, clarify, or fix documentation
 - Suggest or add new features
 
 To get started with development:
 
 ```
-git clone https://github.com/jclusso/heroicon-ruby.git
+git clone https://github.com/jclusso/heroicons.git
 cd heroicon
 bundle install
 bundle exec rake test

--- a/heroicons.gemspec
+++ b/heroicons.gemspec
@@ -7,11 +7,11 @@ require "heroicon/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name = "heroicon-ruby"
+  spec.name = "heroicons"
   spec.version = Heroicon::VERSION
   spec.authors = ["Jarrett Lusso"]
   spec.email = ["jclusso@gmail.com"]
-  spec.homepage = "https://github.com/jclusso/heroicon-ruby"
+  spec.homepage = "https://github.com/jclusso/heroicons"
   spec.summary = "Rails View Helpers for Heroicons."
   spec.description = "Ruby on Rails view helpers for the beautiful hand-crafted SVG icons, Heroicons."
   spec.license = "MIT"


### PR DESCRIPTION
For now this just renames the gem, but in the future, it probably would be nice to switch the rest of the project to use the pluralized version except for the `heroicon` helper which we wouldn't want to change.

Closes: #3 